### PR TITLE
Revised CASH2 Block Reward Estimate

### DIFF
--- a/main.js
+++ b/main.js
@@ -840,7 +840,7 @@ function getBlockReward(CASH2APIheight)
 }
 
 function cash2Reward(difficulty, hashrate, height, period){
-    return (hashrate/(CASH2APIDifficulty/cash2BlockTime)) * ((getBlockReward(CASH2APIheight)  * (period/cash2BlockTime)))
+    return (hashrate/(CASH2APIDifficulty/cash2BlockTime)) * ((getBlockReward(CASH2APIheight + ((period/cash2BlockTime)/2)))  * (period/cash2BlockTime))
 
 }
 }


### PR DESCRIPTION
Now takes the average block reward over the period projects earnings using that.
Before projections were using only current block reward. This led to unrealistically high earning estimates.